### PR TITLE
Place flag before JAR-file

### DIFF
--- a/src/processors/localProcessors.ts
+++ b/src/processors/localProcessors.ts
@@ -191,7 +191,7 @@ export class LocalProcessors implements Processor {
 
         if(jarFullPath.endsWith('.jar')) {
             return [
-                this.plugin.settings.javaPath, '-jar', '"' + jarFullPath + '"', '-Djava.awt.headless=true', '-charset', 'utf-8', '-graphvizdot', '"' + this.plugin.settings.dotPath + '"'
+                this.plugin.settings.javaPath, '-jar', '-Djava.awt.headless=true', '"' + jarFullPath + '"', '-charset', 'utf-8', '-graphvizdot', '"' + this.plugin.settings.dotPath + '"'
             ];
         }
         return [


### PR DESCRIPTION
Reorder command line arguments since flag -Djava.awt.headless=true has no effect being placed after JAR-file