### PR TITLE
fix: do not replace whitespace to avoid mindmap indent

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -13,18 +13,8 @@ export class Replacer {
         this.plugin = plugin;
     }
 
-    public replaceNonBreakingSpaces(text: string): string {
-        const lines = text.split(/\r?\n/);
-        const resultLines: string[] = [];
-        if (text.startsWith("@startmindmap")) {
-            for (const line of lines) {
-                resultLines.push(line.replace(/\s+/g, ' '));
-            }
-        } else {
-            resultLines.push(...lines);
-        }
-        const result = resultLines.join('\r\n');
-        return result.replace(/&nbsp;/gi, " ");
+    public decodeWhiteSpaces(text: string): string {
+        return text.replace(/&nbsp;/gi, " ");
     }
 
     /**

--- a/src/processors/debouncedProcessors.ts
+++ b/src/processors/debouncedProcessors.ts
@@ -50,7 +50,7 @@ export class DebouncedProcessors implements Processor {
             el.dataset.plantumlDebouce = uuid;
             this.debounceMap.set(uuid, func);
 
-            source = this.plugin.replacer.replaceNonBreakingSpaces(source);
+            source = this.plugin.replacer.decodeWhiteSpaces(source);
             source = this.plugin.replacer.replaceLinks(source, this.plugin.replacer.getPath(ctx), filetype);
             source = this.plugin.settings.header + "\r\n" + source;
             await processor(source, el, ctx);


### PR DESCRIPTION
The mindmap requires white space indentation to distinguish node levels.
the document is here https://plantuml.com/mindmap-diagram#2971d30e503e588e .

Replacing the white space may lead the PlantUML server or local PlantUML to utilize incorrect sources.

The PR retains part of the function (decode HTML encoding logic) and eliminates the break spaces replacement logic.