### PR TITLE
FEAT: Fix not working links in embeds and PumlView

### DIFF
--- a/src/PumlView.ts
+++ b/src/PumlView.ts
@@ -1,4 +1,4 @@
-import { debounce, Debouncer, Keymap, MarkdownPostProcessorContext, setIcon, TextFileView, ViewStateResult, WorkspaceLeaf } from "obsidian";
+import { Keymap, MarkdownPostProcessorContext, setIcon, TextFileView, ViewStateResult, WorkspaceLeaf } from "obsidian";
 import PlantumlPlugin from "./main";
 import {
     drawSelection,
@@ -45,7 +45,6 @@ export class PumlView extends TextFileView {
     currentView: 'source' | 'preview';
     plugin: PlantumlPlugin;
     dispatchId = -1;
-    debounced: Debouncer<any>;
     debouncedProcessors: DebouncedProcessors
 
     extensions: Extension[] = [
@@ -68,7 +67,6 @@ export class PumlView extends TextFileView {
         super(leaf);
         this.plugin = plugin;
 
-        this.debounced = debounce(this.plugin.getProcessor().png, this.plugin.settings.debounce * 1000, true);
         this.debouncedProcessors = new DebouncedProcessors(plugin);
 
         this.sourceEl = this.contentEl.createDiv({ cls: 'plantuml-source-view', attr: { 'style': 'display: block' } });
@@ -218,7 +216,6 @@ export class PumlView extends TextFileView {
         const previewDiv = this.previewEl.createDiv();
 
 
-        this.debounced(this.getViewData(), previewDiv, null);
         this.debouncedProcessors.png(this.getViewData(), previewDiv, { sourcePath: this.file.path } as MarkdownPostProcessorContext)
         loadingHeader.remove();
     }

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,21 +1,24 @@
 import {Component, EmbedChild, EmbedContext, TFile} from "obsidian";
 import PlantumlPlugin from "./main";
+import { DebouncedProcessors } from "./processors/debouncedProcessors";
 
 export class PumlEmbed extends Component implements EmbedChild {
     plugin: PlantumlPlugin;
     ctx: EmbedContext;
     file: TFile;
+    debouncedProcessors: DebouncedProcessors;
 
     constructor(plugin: PlantumlPlugin, file: TFile, ctx: EmbedContext) {
         super();
         this.plugin = plugin;
         this.file = file;
         this.ctx = ctx;
+        this.debouncedProcessors = new DebouncedProcessors(plugin);
     }
 
     async loadFile() {
         const data = await this.plugin.app.vault.cachedRead(this.file);
-        await this.plugin.getProcessor().png(data, this.ctx.containerEl, null);
+        await this.debouncedProcessors.png(data, this.ctx.containerEl, this.ctx)
     }
 
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -3,7 +3,7 @@
  * @param text
  * @param path
  */
-import {MarkdownPostProcessorContext} from "obsidian";
+import {EmbedContext, MarkdownPostProcessorContext} from "obsidian";
 import PlantumlPlugin from "./main";
 
 export class Replacer {
@@ -65,7 +65,7 @@ export class Replacer {
         return this.plugin.app.vault.adapter.getFullPath(folder.path);
     }
 
-    public getPath(ctx: MarkdownPostProcessorContext) {
+    public getPath(ctx: MarkdownPostProcessorContext | EmbedContext) {
         return this.getFullPath(ctx ? ctx.sourcePath : '');
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ declare module "obsidian" {
     interface EmbedContext {
         app: App;
         containerEl: HTMLElement;
+        sourcePath: string
     }
 }
 

--- a/src/processors/debouncedProcessors.ts
+++ b/src/processors/debouncedProcessors.ts
@@ -1,4 +1,4 @@
-import { debounce, Debouncer, MarkdownPostProcessorContext, Menu, Notice, TFile } from "obsidian";
+import { debounce, Debouncer, EmbedContext, MarkdownPostProcessorContext, Menu, Notice, TFile } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import PlantumlPlugin from "../main";
 import { Processor } from "./processor";
@@ -7,7 +7,7 @@ export class DebouncedProcessors implements Processor {
 
     SECONDS_TO_MS_FACTOR = 1000;
 
-    debounceMap = new Map<string, Debouncer<[string, HTMLElement, MarkdownPostProcessorContext], unknown>>();
+    debounceMap = new Map<string, Debouncer<[string, HTMLElement, MarkdownPostProcessorContext | EmbedContext], unknown>>();
 
     debounceTime: number;
     plugin: PlantumlPlugin;
@@ -18,23 +18,23 @@ export class DebouncedProcessors implements Processor {
         this.debounceTime = debounceTime * this.SECONDS_TO_MS_FACTOR;
     }
 
-    default = async(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    default = async(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => {
         await this.png(source, el, ctx);
     }
 
-    png = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    png = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => {
         await this.processor(source, el, ctx, "png", this.plugin.getProcessor().png);
     }
 
-    ascii = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    ascii = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => {
         await this.processor(source, el, ctx, "ascii", this.plugin.getProcessor().ascii);
     }
 
-    svg = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    svg = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => {
         await this.processor(source, el, ctx, "svg", this.plugin.getProcessor().svg);
     }
 
-    processor = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext, filetype: string, processor: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => Promise<void>) => {
+    processor = async (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext, filetype: string, processor: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => Promise<void>) => {
         const originalSource = source;
         el.dataset.filetype = filetype;
         el.createEl("h6", {text: "Generating PlantUML diagram", cls: "puml-loading"});

--- a/src/processors/localProcessors.ts
+++ b/src/processors/localProcessors.ts
@@ -1,6 +1,6 @@
 import PlantumlPlugin from "../main";
 import {Processor} from "./processor";
-import {MarkdownPostProcessorContext, moment} from "obsidian";
+import {EmbedContext, MarkdownPostProcessorContext, moment} from "obsidian";
 import * as plantuml from "plantuml-encoder";
 import {insertAsciiImage, insertImageWithMap, insertSvgImage} from "../functions";
 import {OutputType} from "../const";
@@ -14,7 +14,7 @@ export class LocalProcessors implements Processor {
         this.plugin = plugin;
     }
 
-    ascii = async(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    ascii = async(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => {
         const encodedDiagram = plantuml.encode(source);
         const item: string = await localforage.getItem('ascii-' + encodedDiagram);
         if(item) {
@@ -29,7 +29,7 @@ export class LocalProcessors implements Processor {
         await localforage.setItem('ts-' + encodedDiagram, Date.now());
     }
 
-    png = async(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    png = async(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => {
         const encodedDiagram = plantuml.encode(source);
         const item: string = await localforage.getItem('png-' + encodedDiagram);
         if(item) {
@@ -50,7 +50,7 @@ export class LocalProcessors implements Processor {
         insertImageWithMap(el, image, map, encodedDiagram);
     }
 
-    svg = async(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    svg = async(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => {
         const encodedDiagram = plantuml.encode(source);
         const item: string = await localforage.getItem('svg-' + encodedDiagram);
         if(item) {

--- a/src/processors/processor.ts
+++ b/src/processors/processor.ts
@@ -1,7 +1,7 @@
-import {MarkdownPostProcessorContext} from "obsidian";
+import {EmbedContext, MarkdownPostProcessorContext} from "obsidian";
 
 export interface Processor {
-    svg: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => Promise<void>;
-    png: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => Promise<void>;
-    ascii: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) => Promise<void>;
+    svg: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => Promise<void>;
+    png: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => Promise<void>;
+    ascii: (source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext | EmbedContext) => Promise<void>;
 }

--- a/src/processors/serverProcessor.ts
+++ b/src/processors/serverProcessor.ts
@@ -1,4 +1,4 @@
-import {MarkdownPostProcessorContext, request} from "obsidian";
+import {EmbedContext, MarkdownPostProcessorContext, request} from "obsidian";
 import {DEFAULT_SETTINGS} from "../settings";
 import * as plantuml from "plantuml-encoder";
 import PlantumlPlugin from "../main";
@@ -12,7 +12,7 @@ export class ServerProcessor implements Processor {
         this.plugin = plugin;
     }
 
-    svg = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
+    svg = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext | EmbedContext) => {
         //make sure url is defined. once the setting gets reset to default, an empty string will be returned by settings
         let url = this.plugin.settings.server_url;
         if (url.length == 0) {
@@ -30,7 +30,7 @@ export class ServerProcessor implements Processor {
         });
     };
 
-    png = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
+    png = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext | EmbedContext) => {
         //make sure url is defined. once the setting gets reset to default, an empty string will be returned by settings
         let url = this.plugin.settings.server_url;
         if (url.length == 0) {
@@ -48,7 +48,7 @@ export class ServerProcessor implements Processor {
 
         insertImageWithMap(el, image, map, encodedDiagram);
     }
-    ascii = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
+    ascii = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext | EmbedContext) => {
         //make sure url is defined, once the setting gets reset to default, an empty string will be returned by settings
         let url = this.plugin.settings.server_url;
         if (url.length == 0) {


### PR DESCRIPTION
I discovered that links are not working for embeds and PumlView because of the missing processing in DebouncedProcessors.

Some Files for testing:
[Sandbox.md](https://github.com/user-attachments/files/22068454/Sandbox.md)
[Test 1.md](https://github.com/user-attachments/files/22068455/Test.1.md)
[Sandbox.puml.md](https://github.com/user-attachments/files/22068457/Sandbox.puml.md)
[Test 2.md](https://github.com/user-attachments/files/22068456/Test.2.md)

For ``Sandbox.puml.md `` you have to remove the .md because GitHub does not support .puml