### PR TITLE
Fix: JVM headless flags placed after -jar have no effect

### DIFF
--- a/src/processors/localProcessors.ts
+++ b/src/processors/localProcessors.ts
@@ -191,11 +191,11 @@ export class LocalProcessors implements Processor {
 
         if(jarFullPath.endsWith('.jar')) {
             return [
-                this.plugin.settings.javaPath, '-jar', '-Djava.awt.headless=true', '"' + jarFullPath + '"', '-charset', 'utf-8', '-graphvizdot', '"' + this.plugin.settings.dotPath + '"'
+                this.plugin.settings.javaPath, '-Djava.awt.headless=true', '-Dapple.awt.UIElement=true', '-jar', '"' + jarFullPath + '"', '-charset', 'utf-8', '-graphvizdot', '"' + this.plugin.settings.dotPath + '"'
             ];
         }
         return [
-            jarFullPath, '-Djava.awt.headless=true', '-charset', 'utf-8', '-graphvizdot', '"' + this.plugin.settings.dotPath + '"'
+            jarFullPath, '-Djava.awt.headless=true', '-Dapple.awt.UIElement=true', '-charset', 'utf-8', '-graphvizdot', '"' + this.plugin.settings.dotPath + '"'
         ];
     }
 }


### PR DESCRIPTION
## Problem

On macOS, when rendering PlantUML diagrams locally, the Java process steals window focus — a Java icon appears in the Dock, and the Java window comes to the foreground pushing Obsidian to the background. This is very disruptive during normal note-taking workflow.

### Root cause

In `localProcessors.ts`, the `-Djava.awt.headless=true` flag is placed **after** the `-jar` argument:

```
java -jar -Djava.awt.headless=true "plantuml.jar" ...
```

JVM system properties (`-D` flags) must appear **before** `-jar` to be recognized by the JVM. Everything after `-jar <jarfile>` is passed as arguments to the application's `main()` method, not to the JVM itself. This means headless mode was never actually enabled.

Reference: [java command documentation](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html) — *"In the third form, the JVM launches the Java application specified by the JAR file. The arguments after the JAR file are passed as arguments to the application's main method."*

## Fix

1. Move `-Djava.awt.headless=true` **before** `-jar` so the JVM actually applies it
2. Add `-Dapple.awt.UIElement=true` — a macOS-specific property that prevents Java from registering as a GUI application (no Dock icon, no focus stealing)

### Before
```
java -jar -Djava.awt.headless=true "plantuml.jar" -charset utf-8 ...
```

### After
```
java -Djava.awt.headless=true -Dapple.awt.UIElement=true -jar "plantuml.jar" -charset utf-8 ...
```

## Testing

Tested on macOS Sequoia with local PlantUML jar rendering. After the fix, diagrams render correctly with no visible Java process, no Dock icon, and no focus stealing.