### PR TITLE
Made dark mode usable for Docker users

### DIFF
--- a/src/processors/serverProcessor.ts
+++ b/src/processors/serverProcessor.ts
@@ -8,9 +8,6 @@ import {insertAsciiImage, insertImageWithMap, insertSvgImage} from "../functions
 export class ServerProcessor implements Processor {
     plugin: PlantumlPlugin;
 
-    //Docker deploys do not serve the dark mode endpoints yet
-    readonly isDockerDarkModeEndpointBroken = true;
-
     constructor(plugin: PlantumlPlugin) {
         this.plugin = plugin;
     }
@@ -30,7 +27,8 @@ export class ServerProcessor implements Processor {
     }
 
     svg = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
-        const endpoint = this.isDark()||(this.isDockerServer()&&!this.isDockerDarkModeEndpointBroken)?"/dsvg/":"/svg/"
+        //Docker deploys do not serve the dark mode endpoints
+        const endpoint = this.isDark()||!this.isDockerServer()?"/dsvg/":"/svg/"
         const imageUrlBase = this.getUrl() + endpoint;
         const headers = this.isDark()?{"X-Preferred-Color-Mapper": "DARK_MODE"}:{}
         const encodedDiagram = plantuml.encode(source);
@@ -49,7 +47,8 @@ export class ServerProcessor implements Processor {
 
     png = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
         const url = this.getUrl();
-        const endpoint = this.isDark()||(this.isDockerServer()&& !this.isDockerDarkModeEndpointBroken)?"/dpng/":"/png/"
+        //Docker deploys do not serve the dark mode endpoints
+        const endpoint = this.isDark()||!this.isDockerServer()?"/dpng/":"/png/"
         const headers = this.isDark()?{"X-Preferred-Color-Mapper": "DARK_MODE"}:{}
         const imageUrlBase = url + endpoint;
         const encodedDiagram = plantuml.encode(source);

--- a/src/processors/serverProcessor.ts
+++ b/src/processors/serverProcessor.ts
@@ -28,7 +28,7 @@ export class ServerProcessor implements Processor {
 
     svg = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
         //Docker deploys do not serve the dark mode endpoints
-        const endpoint = this.isDark()||!this.isDockerServer()?"/dsvg/":"/svg/"
+        const endpoint = this.isDark()&&!this.isDockerServer()?"/dsvg/":"/svg/"
         const imageUrlBase = this.getUrl() + endpoint;
         const headers = this.isDark()?{"X-Preferred-Color-Mapper": "DARK_MODE"}:{}
         const encodedDiagram = plantuml.encode(source);
@@ -48,7 +48,7 @@ export class ServerProcessor implements Processor {
     png = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
         const url = this.getUrl();
         //Docker deploys do not serve the dark mode endpoints
-        const endpoint = this.isDark()||!this.isDockerServer()?"/dpng/":"/png/"
+        const endpoint = this.isDark()&&!this.isDockerServer()?"/dpng/":"/png/"
         const headers = this.isDark()?{"X-Preferred-Color-Mapper": "DARK_MODE"}:{}
         const imageUrlBase = url + endpoint;
         const encodedDiagram = plantuml.encode(source);

--- a/src/processors/serverProcessor.ts
+++ b/src/processors/serverProcessor.ts
@@ -1,4 +1,4 @@
-import {MarkdownPostProcessorContext, request} from "obsidian";
+import {MarkdownPostProcessorContext, request, requestUrl} from "obsidian";
 import {DEFAULT_SETTINGS} from "../settings";
 import * as plantuml from "plantuml-encoder";
 import PlantumlPlugin from "../main";
@@ -8,8 +8,16 @@ import {insertAsciiImage, insertImageWithMap, insertSvgImage} from "../functions
 export class ServerProcessor implements Processor {
     plugin: PlantumlPlugin;
 
+    //Docker deploys do not serve the dark mode endpoints yet
+    readonly isDockerDarkModeEndpointBroken = true;
+
     constructor(plugin: PlantumlPlugin) {
         this.plugin = plugin;
+    }
+
+    //This is an assumption that might not be true for all cases
+    private isDockerServer(): boolean{
+        return this.plugin.settings.server_url.length>0;
     }
 
     private getUrl(): string {
@@ -22,10 +30,16 @@ export class ServerProcessor implements Processor {
     }
 
     svg = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
-        const imageUrlBase = this.getUrl() + (this.isDark() ? "/dsvg/" : "/svg/");
+        const endpoint = this.isDark()||(this.isDockerServer()&&!this.isDockerDarkModeEndpointBroken)?"/dsvg/":"/svg/"
+        const imageUrlBase = this.getUrl() + endpoint;
+        const headers = this.isDark()?{"X-Preferred-Color-Mapper": "DARK_MODE"}:{}
         const encodedDiagram = plantuml.encode(source);
 
-        request({url: imageUrlBase + encodedDiagram, method: 'GET'}).then((value: string) => {
+        request({
+            url: imageUrlBase + encodedDiagram,
+            method: 'GET',
+            headers
+        }).then((value: string) => {
             insertSvgImage(el, value);
         }).catch((error: Error) => {
             if (error)
@@ -35,10 +49,22 @@ export class ServerProcessor implements Processor {
 
     png = async(source: string, el: HTMLElement, _: MarkdownPostProcessorContext) => {
         const url = this.getUrl();
-        const imageUrlBase = url + (this.isDark() ? "/dpng/" : "/png/");
-
+        const endpoint = this.isDark()||(this.isDockerServer()&& !this.isDockerDarkModeEndpointBroken)?"/dpng/":"/png/"
+        const headers = this.isDark()?{"X-Preferred-Color-Mapper": "DARK_MODE"}:{}
+        const imageUrlBase = url + endpoint;
         const encodedDiagram = plantuml.encode(source);
-        const image = imageUrlBase + encodedDiagram;
+
+        const response = await requestUrl({
+        url: imageUrlBase + encodedDiagram,
+        method: "GET",
+        headers
+        });
+        const bytes = new Uint8Array(response.arrayBuffer);
+        let binary = "";
+        for (const byte of bytes){
+            binary += String.fromCharCode(byte);
+        }
+        const image = btoa(binary);
 
         //get image map data to support clicking links in diagrams
         const mapUrlBase = url + "/map/";

--- a/src/processors/serverProcessor.ts
+++ b/src/processors/serverProcessor.ts
@@ -14,7 +14,7 @@ export class ServerProcessor implements Processor {
 
     //This is an assumption that might not be true for all cases
     private isDockerServer(): boolean{
-        return this.plugin.settings.server_url.length>0;
+        return this.plugin.settings.docker_server;
     }
 
     private getUrl(): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import PlantumlPlugin from "./main";
 
 export interface PlantUMLSettings {
     server_url: string,
+    docker_server: boolean;
     header: string;
     debounce: number;
     localJar: string;
@@ -17,6 +18,7 @@ export interface PlantUMLSettings {
 
 export const DEFAULT_SETTINGS: PlantUMLSettings = {
     server_url: 'https://www.plantuml.com/plantuml',
+    docker_server: false,
     header: '',
     debounce: 3,
     localJar: '',
@@ -40,14 +42,29 @@ export class PlantUMLSettingsTab extends PluginSettingTab {
     getSettingDefinitions(): SettingDefinitionItem[] {
         return [
             {
-                name: 'Server URL',
-                desc: 'PlantUML server URL',
-                control: {
-                    type: 'text',
-                    key: 'server_url',
-                    placeholder: DEFAULT_SETTINGS.server_url,
-                    defaultValue: DEFAULT_SETTINGS.server_url,
-                }
+                type: 'group',
+                heading: 'Server rendering',
+                items: [
+                    {
+                        name: 'Server URL',
+                        desc: 'PlantUML server URL',
+                        control: {
+                            type: 'text',
+                            key: 'server_url',
+                            placeholder: DEFAULT_SETTINGS.server_url,
+                            defaultValue: DEFAULT_SETTINGS.server_url,
+                        }
+                    },
+                    {
+                        name: 'Docker server',
+                        desc: 'Check if the PlantUML server is a Docker deployment. This will disable dark mode endpoints.',
+                        control: {
+                            type: 'toggle',
+                            key: 'docker_server',
+                            defaultValue: DEFAULT_SETTINGS.docker_server,
+                        }
+                    }
+                ]
             },
             {
                 type: 'group',


### PR DESCRIPTION
-Refactored PNG rendering to use requestUrl, allowing custom HTTP headers to be sent with the request.
-Added support for the 'X-Preferred-Color-Mapper' header for dark-mode rendering.
-Added non dark mode endpoint as fallback for dark mode users with broken endpoints.
-Added flag for when Docker dark mode endpoints gets fixed.

# Related issues

Fixes #85

Related:
- plantuml/plantuml-server#314
- plantuml/plantuml-server#424